### PR TITLE
let's make XAConnectionFactory optional in pax-transx-jms

### DIFF
--- a/pax-transx-jms/src/main/java/org/ops4j/pax/transx/jms/impl/ManagedConnectionFactoryImpl.java
+++ b/pax-transx-jms/src/main/java/org/ops4j/pax/transx/jms/impl/ManagedConnectionFactoryImpl.java
@@ -36,7 +36,6 @@ public class ManagedConnectionFactoryImpl
 
     public ManagedConnectionFactoryImpl(ConnectionFactory connectionFactory, XAConnectionFactory xaConnectionFactory, ExceptionSorter exceptionSorter) {
         assert connectionFactory != null;
-        assert xaConnectionFactory != null;
         assert exceptionSorter != null;
         this.connectionFactory = connectionFactory;
         this.xaConnectionFactory = xaConnectionFactory;
@@ -45,7 +44,7 @@ public class ManagedConnectionFactoryImpl
 
     @Override
     public TransactionSupportLevel getTransactionSupport() {
-        return TransactionSupportLevel.XATransaction;
+        return xaConnectionFactory != null ? TransactionSupportLevel.XATransaction : TransactionSupportLevel.LocalTransaction;
     }
 
     public ConnectionFactory getConnectionFactory() {


### PR DESCRIPTION
Apache Qpid's JMS client library doesn't implement XAConnectionFactory [yet](https://issues.apache.org/jira/projects/QPIDJMS/issues/QPIDJMS-206). This is needed in https://github.com/ops4j/org.ops4j.pax.jms/pull/7

Thanks!