### PR TITLE
Unsynchronized multithread HashMap access in transaction manager wrappers

### DIFF
--- a/pax-transx-tm-atomikos/src/main/java/org/ops4j/pax/transx/tm/impl/atomikos/TransactionManagerWrapper.java
+++ b/pax-transx-tm-atomikos/src/main/java/org/ops4j/pax/transx/tm/impl/atomikos/TransactionManagerWrapper.java
@@ -27,13 +27,14 @@ import org.ops4j.pax.transx.tm.impl.AbstractTransactionManagerWrapper;
 
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class TransactionManagerWrapper extends AbstractTransactionManagerWrapper<TransactionManager> {
 
-    Map<String, ResourceFactory> resources = new HashMap<>();
-    Map<ResourceFactory, XATransactionalResource> recoverables = new HashMap<>();
+    Map<String, ResourceFactory> resources = Collections.synchronizedMap(new HashMap<>());
+    Map<ResourceFactory, XATransactionalResource> recoverables = Collections.synchronizedMap(new HashMap<>());
 
     public TransactionManagerWrapper() {
         this(initTransactionManager());

--- a/pax-transx-tm-core/src/main/java/org/ops4j/pax/transx/tm/impl/AbstractTransactionManagerWrapper.java
+++ b/pax-transx-tm-core/src/main/java/org/ops4j/pax/transx/tm/impl/AbstractTransactionManagerWrapper.java
@@ -26,6 +26,8 @@ import org.ops4j.pax.transx.tm.TransactionManager;
 import javax.transaction.RollbackException;
 import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.function.Consumer;
@@ -33,7 +35,7 @@ import java.util.function.Consumer;
 public abstract class AbstractTransactionManagerWrapper<TM extends javax.transaction.TransactionManager> implements TransactionManager {
 
     protected final TM tm;
-    protected final WeakHashMap<javax.transaction.Transaction, TransactionWrapper> transactions = new WeakHashMap<>();
+    protected final Map<javax.transaction.Transaction, TransactionWrapper> transactions = Collections.synchronizedMap(new WeakHashMap<>());
 
     public AbstractTransactionManagerWrapper(TM tm) {
         this.tm = tm;

--- a/pax-transx-tm-geronimo/src/main/java/org/ops4j/pax/transx/tm/impl/geronimo/TransactionManagerWrapper.java
+++ b/pax-transx-tm-geronimo/src/main/java/org/ops4j/pax/transx/tm/impl/geronimo/TransactionManagerWrapper.java
@@ -28,13 +28,14 @@ import org.ops4j.pax.transx.tm.ResourceFactory;
 import org.ops4j.pax.transx.tm.impl.AbstractTransactionManagerWrapper;
 
 import javax.transaction.SystemException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
 public class TransactionManagerWrapper extends AbstractTransactionManagerWrapper<GeronimoTransactionManager> {
 
-    protected final Map<String, ResourceFactory> resources = new HashMap<>();
+    protected final Map<String, ResourceFactory> resources = Collections.synchronizedMap(new HashMap<>());
 
     public TransactionManagerWrapper(GeronimoTransactionManager geronimoTransactionManager) {
         super(geronimoTransactionManager);

--- a/pax-transx-tm-narayana/src/main/java/org/jboss/narayana/osgi/jta/internal/TransactionManagerWrapper.java
+++ b/pax-transx-tm-narayana/src/main/java/org/jboss/narayana/osgi/jta/internal/TransactionManagerWrapper.java
@@ -30,14 +30,15 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import java.lang.reflect.Proxy;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class TransactionManagerWrapper extends AbstractTransactionManagerWrapper<TransactionManager> {
 
     final RecoveryManagerService recoveryManagerService;
-    final Map<String, ResourceFactory> resources = new HashMap<>();
-    final Map<ResourceFactory, XAResourceRecovery> recoverables = new HashMap<>();
+    final Map<String, ResourceFactory> resources = Collections.synchronizedMap(new HashMap<>());
+    final Map<ResourceFactory, XAResourceRecovery> recoverables = Collections.synchronizedMap(new HashMap<>());
 
     public TransactionManagerWrapper(TransactionManager narayanaTransactionManager) {
         super(narayanaTransactionManager);


### PR DESCRIPTION
As result many JVM freezes with stacks like this:

`"schedulerSyncChanges-1" Id=162 in RUNNABLE
at java.util.WeakHashMap.transfer(WeakHashMap.java:528)
at java.util.WeakHashMap.resize(WeakHashMap.java:493)
at java.util.WeakHashMap.put(WeakHashMap.java:466)
at java.util.Map.computeIfAbsent(Map.java:958)
at org.ops4j.pax.transx.tm.impl.AbstractTransactionManagerWrapper.getTransaction(AbstractTransactionManagerWrapper.java:49)
at org.ops4j.pax.transx.connector.impl.GenericConnectionManager.getMci(GenericConnectionManager.java:186)
at org.ops4j.pax.transx.connector.impl.GenericConnectionManager.allocateConnection(GenericConnectionManager.java:171)
at org.ops4j.pax.transx.connector.impl.GenericConnectionManager.allocateConnection(GenericConnectionManager.java:167)
at org.ops4j.pax.transx.jdbc.impl.TransxDataSource.getConnection(TransxDataSource.java:68)
at org.ops4j.pax.transx.jdbc.impl.TransxDataSource.getConnection(TransxDataSource.java:59)
at sun.reflect.GeneratedMethodAccessor328.invoke(Unknown Source)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)`

